### PR TITLE
Small fix formatting of enums

### DIFF
--- a/CPP2D/DPrinter.cpp
+++ b/CPP2D/DPrinter.cpp
@@ -2354,7 +2354,10 @@ bool DPrinter::TraverseEnumConstantDecl(EnumConstantDecl* Decl)
 bool DPrinter::TraverseEnumDecl(EnumDecl* Decl)
 {
 	if(passDecl(Decl)) return true;
-	out() << "enum " << mangleName(Decl->getNameAsString());
+	out() << "enum";
+	if (Decl->getDeclName()) {
+		out() << " " << mangleName(Decl->getNameAsString());
+	}
 	if(Decl->isFixed())
 	{
 		out() << " : ";


### PR DESCRIPTION
Removes a waste space when declaring anoymous enums like

enum {
    OPT0, OP1
};

->

enum : int {

Without the fix there will be a superfluous space between then enum and the :.
