### PR TITLE
Fix build when compiling with CMake and Clang

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,9 +26,9 @@ install:
 script:	  
   - mkdir -p build
   - cd build
-  - cmake .. -DLLVM_INCLUDE=/usr/lib/llvm-6.0/include -DLLVM_LIB=/usr/lib/llvm-6.0/lib -DCLANG_INCLUDE=/usr/lib/llvm-6.0/include/clang -DCLANG_LIB=/usr/lib/llvm-6.0/lib -DCMAKE_EXPORT_COMPILE_COMMANDS=OFF
+  - cmake .. -DCMAKE_PREFIX_PATH=/usr/lib/llvm-6.0 -DCMAKE_EXPORT_COMPILE_COMMANDS=OFF
   - make
-  - cmake .. -DLLVM_INCLUDE=/usr/lib/llvm-6.0/include -DLLVM_LIB=/usr/lib/llvm-6.0/lib -DCLANG_INCLUDE=/usr/lib/llvm-6.0/include/clang -DCLANG_LIB=/usr/lib/llvm-6.0/lib -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
+  - cmake .. -DCMAKE_PREFIX_PATH=/usr/lib/llvm-6.0 -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
   - ln -s $PWD/compile_commands.json ../CPP2D_UT_CPP
   - cd ../CPP2D_UT_CPP
   - ../build/CPP2D/cpp2d stdlib_testsuite.cpp template_testsuite.cpp test.cpp framework.cpp main.cpp  -macro-expr=UT_MACRO_EXPR/nn -macro-expr=CHECK/e -macro-expr=CHECK_EQUAL/ee -macro-expr=UT_MACRO/eee -macro-stmt=UT_MACRO_STMT -macro-stmt=UT_MACRO_STMT_CLASS/ntne

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,5 +2,13 @@ cmake_minimum_required(VERSION 2.6)
 
 project(cpp2d)
 
+if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++14 -fno-rtti")
+endif()
+
+find_package(LLVM 6 REQUIRED)
+include_directories(${LLVM_INCLUDE_DIRS})
+link_directories(${LLVM_LIBRARY_DIRS})
+
 add_subdirectory(CPP2D)
 add_subdirectory(CPP2D_UT_CPP)

--- a/CPP2D/CMakeLists.txt
+++ b/CPP2D/CMakeLists.txt
@@ -2,30 +2,6 @@ cmake_minimum_required(VERSION 2.6)
 
 project(cpp2d)
 
-find_path(LLVM_INCLUDE llvm
-   PATH_SUFFIXES llvm
-   DOC "Include directory for llvm"
-   )
-include_directories(${LLVM_INCLUDE})
-
-find_path(LLVM_LIB llvm
-   PATH_SUFFIXES llvm
-   DOC "Lib directory for llvm"
-)
-link_directories(${LLVM_LIB})
-
-find_path(CLANG_INCLUDE clang
-   PATH_SUFFIXES clang
-   DOC "Include directory for clang"
-)
-include_directories(${CLANG_INCLUDE})
-
-find_path(CLANG_LIB clang
-   PATH_SUFFIXES clang
-   DOC "Lib directory for clang"
-)
-link_directories(${CLANG_LIB})
-
 # Déclaration de l'exécutable
 add_executable(
     cpp2d
@@ -83,7 +59,6 @@ target_link_libraries(cpp2d
 )
 
 if(CMAKE_COMPILER_IS_GNUCXX)
-    SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++14 -fno-rtti")
     target_link_libraries(cpp2d rt dl tinfo pthread z m)
 endif()
 

--- a/CPP2D/CustomPrinters/boost_port.cpp
+++ b/CPP2D/CustomPrinters/boost_port.cpp
@@ -6,6 +6,7 @@
 //
 
 #include <ciso646>
+#include <ostream>
 
 #pragma warning(push, 0)
 #pragma warning(disable: 4265)

--- a/CPP2D/CustomPrinters/cpp_stdlib_port.cpp
+++ b/CPP2D/CustomPrinters/cpp_stdlib_port.cpp
@@ -6,6 +6,7 @@
 //
 
 #include <ciso646>
+#include <ostream>
 
 #pragma warning(push, 0)
 #pragma warning(disable: 4265)

--- a/CPP2D_UT_CPP/CMakeLists.txt
+++ b/CPP2D_UT_CPP/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 2.6)
 project(CPP2D_UT_CPP)
 
 if(CMAKE_EXPORT_COMPILE_COMMANDS STREQUAL "ON")
-    include_directories(${LLVM_LIB}/clang/4.0.1/include)
+    include_directories(${LLVM_LIBRARY_DIRS}/clang/6.0.1/include)
 endif()
 
 # Déclaration de l'exécutable
@@ -15,6 +15,3 @@ add_executable(
 	stdlib_testsuite.cpp
 	template_testsuite.cpp
 )
-if(CMAKE_COMPILER_IS_GNUCXX)
-    SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++1y -fno-rtti")
-endif()

--- a/README.md
+++ b/README.md
@@ -54,15 +54,15 @@ Some samples here : https://github.com/lhamot/CPP2D/wiki/Conversion-samples
 
 ## Requirements
 * cmake >= 2.6
-* Tested with **gcc** 4.8.4 (**Ubuntu** 14.04.3) and **Visual Studio** 2015 (**Windows** 7 & 10)
-* Tested with **LLVM/clang** **4.0.1**
+* Tested with **gcc** 4.8.4 (**Ubuntu** 14.04.3), **Visual Studio** 2015 (**Windows** 7 & 10), and **clang** (**macOS** 10.14)
+* Tested with **LLVM/clang** **6.0.1**
 
 ## How to install it?
 1. Install **clang** : http://clang.llvm.org/get_started.html
 2. Check out **CPP2D** from : https://github.com/lhamot/CPP2D.git
 3. Run **cmake** in the root directory of **CPP2D**
    1. Set the build type if needed (Debug;Release;MinSizeRel;RelWithDebInfo)
-   2. Set the path to **LLVM** named **LLVM_PATH**.
+   2. Set the path to **LLVM** using **CMAKE_PREFIX_PATH**.
    4. Generate
 4. Run **make**
 


### PR DESCRIPTION
First of all, thanks for creating and maintaining this useful project!

I tried building it on my system (macOS) with Clang as the C++ compiler. It didn't work out of the box, so here are some fixes that I used to get it to build:

- Use find_package to find LLVM and Clang, now only CMAKE_PREFIX_PATH needs to be specified.
- Pass -std=c++14 and -fno-rtti also when compiler is Clang.
- Add some missing includes.

With these changes I was able to convert a C++ project to D successfully.

I don't know if it still works on e.g. Windows with CMAKE_PREFIX_PATH, so it may be worth testing, but I'm putting this PR up if you want to merge some of the changes. I hope this helps!